### PR TITLE
chore: registers Globus client information with the SDK

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -9,8 +9,10 @@ import {
   Flex,
   Text,
 } from "@chakra-ui/react";
+import { info } from "@globus/sdk/cjs";
 import theme from "@/theme";
 import { STATIC, getEnvironment, getRedirectUri } from "@/utils/static";
+import { CLIENT_INFO } from "@/utils/globus";
 import Header from "@/components/Header";
 import { GlobusAuthorizationManagerProvider } from "@/components/globus-auth-context/Provider";
 
@@ -21,6 +23,8 @@ if (env) {
   // @ts-ignore
   globalThis.GLOBUS_SDK_ENVIRONMENT = env;
 }
+
+info.addClientInfo(CLIENT_INFO);
 
 const redirect = getRedirectUri();
 const client = STATIC.data.attributes.globus.application.client_id;

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,6 +10,7 @@
       "prerelease": false,
       "include-v-in-tag": false,
       "include-component-in-tag": false,
+      "extra-files": ["utils/globus.ts"],
       "changelog-sections": [
         {
           "type": "feat",

--- a/utils/globus.ts
+++ b/utils/globus.ts
@@ -1,5 +1,12 @@
 import type { FileDocument } from "@globus/sdk/cjs/lib/services/transfer/service/file-operations";
 
+export const CLIENT_INFO = {
+  product: "@globus/static-data-portal",
+  // x-release-please-start-version
+  version: "1.3.0",
+  // x-release-please-end
+};
+
 /**
  * This module provides utilities for working with the Globus API.
  * All these methods are candidates for being moved to the Globus SDK.


### PR DESCRIPTION
This will result in the product and version to be sent along with Globus SDK generated requests.

Example: `X-Globus-ClientInfo:
product=javascript-sdk,version=3.4.0;product=@globus/static-data-portal,version=1.3.0`