### PR TITLE
feat: adds support for "content" directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+content
 
 # dependencies
 /node_modules

--- a/README.md
+++ b/README.md
@@ -15,3 +15,22 @@ This is a Globus-powered research data portal `generator` created using Next.js.
 ---
 
 This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+
+## Developer Documentation
+
+### `static.json`
+
+- The `static.json` file is the main configuration file for the data portal.
+- The `utils/static.ts` file is used to enforce a TypeScript type on this file.
+- All pages and components that source information from the user-provided `static.json` should use `utils/static.ts` and its available helpers.
+- Typedoc is configured to generate documentation from `utils/static.ts`.
+
+### MDX Support
+
+[MDX](https://nextjs.org/docs/pages/building-your-application/configuring/mdx) support has been added to the project.
+
+For simple pages, e.g. "Terms and Conditions" and "Privacy Policy" `.mdx` is used to simplify these files being overwritten by end consumers using a `overrides` or `content` directory.
+
+### `content` Directory
+
+A end-user provided `content` directory can be defined to provide MDX files that will be added as `pages` in the Next.js project. This allows for the end-user to provide custom pages without modifying the core project (via `overrides`). This also allows us to provide backwards compatibility should we decide to move away from Next.js in the future.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "dev": "next dev",
+    "prebuild": "node scripts/prebuild.js",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -1,0 +1,26 @@
+/**
+ * Node.js script to be run before `npm run build`
+ */
+
+const { stat, cp } = require("node:fs/promises");
+const { join } = require("node:path");
+
+/**
+ * Sync the user-provided `content` directory with the `pages` directory.
+ */
+async function syncContentDirectory() {
+  const CONTENT_DIR = join(__dirname, "..", "content");
+  const exists = await stat(CONTENT_DIR).catch(() => false);
+  if (!exists || !exists.isDirectory()) {
+    return;
+  }
+  /**
+   * Copy the contents of the directory to the `pages` directory.
+   */
+  await cp(CONTENT_DIR, join(__dirname, "..", "pages"), {
+    recursive: true,
+    force: true,
+  });
+}
+
+syncContentDirectory();


### PR DESCRIPTION
By adding a `.md` or `.mdx` file to a `content` directory end-users can create arbitrary pages in their portal.