### PR TITLE
fix(Search): Ensures GCSv5 Endpoints ("nonfunctional" endpoints that do not support transfer) are not displayed in destination collection search results.

### DIFF
--- a/components/CollectionSearch.tsx
+++ b/components/CollectionSearch.tsx
@@ -38,6 +38,11 @@ export function CollectionSearch({
       const response = await transfer.endpointSearch(
         {
           query: {
+            /**
+             * In the context of the data portal, we only want to return
+             * results that will support Globus Transfer behaviors.
+             */
+            filter_non_functional: false,
             filter_fulltext: query,
             limit: 20,
           },


### PR DESCRIPTION
Uses the `filter_non_functional` query parameter to filter out GCS Endpoints.