### PR TITLE
feat(Theming): Use "primary" and "secondary" color palettes for theming instead of "brand".

### DIFF
--- a/docs/-internal-.md
+++ b/docs/-internal-.md
@@ -12,7 +12,7 @@
 
 #### Defined in
 
-[theme.ts:5](https://github.com/globus/static-data-portal/blob/1b3fe99b60b8d3ee1c63518384fabe5e257a214e/theme.ts#L5)
+[theme.ts:9](https://github.com/globus/static-data-portal/blob/7049be242b3135e7c2d5b874f564022879c85966/theme.ts#L9)
 
 ***
 
@@ -22,7 +22,7 @@
 
 #### Defined in
 
-[components/Navigation.tsx:21](https://github.com/globus/static-data-portal/blob/1b3fe99b60b8d3ee1c63518384fabe5e257a214e/components/Navigation.tsx#L21)
+[components/Navigation.tsx:21](https://github.com/globus/static-data-portal/blob/7049be242b3135e7c2d5b874f564022879c85966/components/Navigation.tsx#L21)
 
 ***
 
@@ -38,7 +38,7 @@
 
 #### Defined in
 
-[components/Navigation.tsx:33](https://github.com/globus/static-data-portal/blob/1b3fe99b60b8d3ee1c63518384fabe5e257a214e/components/Navigation.tsx#L33)
+[components/Navigation.tsx:33](https://github.com/globus/static-data-portal/blob/7049be242b3135e7c2d5b874f564022879c85966/components/Navigation.tsx#L33)
 
 ***
 
@@ -98,14 +98,14 @@ https://v2.chakra-ui.com/docs/styled-system/theme#colors for available color sch
 > `optional` **colors**: [`Record`](-internal-.md#recordk-t)\<`string`, [`ColorDefinition`](-internal-.md#colordefinition)\>
 
 Specific color definitions to use in the theme.
-The most common use case is to define a `brand` color.
+The most common use case is to define a `primary` color.
 
 ###### Example
 
 ```json
 {
   "colors": {
-    "brand": {
+    "primary": {
      "50": "#E5F2FF",
      "100": "#B8DBFF",
      "200": "#8AC4FF",
@@ -137,7 +137,38 @@ https://v2.chakra-ui.com/docs/styled-system/customize-theme#using-theme-extensio
 
 #### Defined in
 
-[theme.ts:20](https://github.com/globus/static-data-portal/blob/1b3fe99b60b8d3ee1c63518384fabe5e257a214e/theme.ts#L20)
+[theme.ts:24](https://github.com/globus/static-data-portal/blob/7049be242b3135e7c2d5b874f564022879c85966/theme.ts#L24)
+
+***
+
+### TransferCollectionConfiguration
+
+> **TransferCollectionConfiguration**: `object`
+
+#### Type declaration
+
+##### collection\_id
+
+> **collection\_id**: `string`
+
+The UUID of the Globus collection to list and transfer files from.
+
+##### label?
+
+> `optional` **label**: `string`
+
+A human-readable label for the Source Selector. If not provided,
+the Collection's `display_name` (and `path`) will be used.
+
+##### path?
+
+> `optional` **path**: `string`
+
+The path on the collection to list and transfer files from.
+
+#### Defined in
+
+[pages/transfer.tsx:45](https://github.com/globus/static-data-portal/blob/7049be242b3135e7c2d5b874f564022879c85966/pages/transfer.tsx#L45)
 
 ## Functions
 

--- a/docs/_media/globals.md
+++ b/docs/_media/globals.md
@@ -75,7 +75,7 @@ https://github.com/from-static/actions
 
 #### Defined in
 
-[utils/static.ts:8](https://github.com/globus/static-data-portal/blob/1b3fe99b60b8d3ee1c63518384fabe5e257a214e/utils/static.ts#L8)
+[utils/static.ts:9](https://github.com/globus/static-data-portal/blob/7049be242b3135e7c2d5b874f564022879c85966/utils/static.ts#L9)
 
 ***
 
@@ -177,21 +177,9 @@ To use the portal's built-in authorization handling, redirects should be sent to
 
 ##### attributes.globus.transfer
 
-> **transfer**: `object`
+> **transfer**: [`TransferCollectionConfiguration`](-internal-.md#transfercollectionconfiguration) \| `object`
 
 Configuration for Transfer-related functionality in the portal.
-
-##### attributes.globus.transfer.collection\_id
-
-> **collection\_id**: `string`
-
-The UUID of the Globus collection to list and transfer files from.
-
-##### attributes.globus.transfer.path?
-
-> `optional` **path**: `string`
-
-The path on the collection to list and transfer files from.
 
 ##### attributes.theme?
 
@@ -212,7 +200,7 @@ the generator will render its `attributes`.
 
 #### Defined in
 
-[utils/static.ts:38](https://github.com/globus/static-data-portal/blob/1b3fe99b60b8d3ee1c63518384fabe5e257a214e/utils/static.ts#L38)
+[utils/static.ts:39](https://github.com/globus/static-data-portal/blob/7049be242b3135e7c2d5b874f564022879c85966/utils/static.ts#L39)
 
 ***
 
@@ -228,7 +216,7 @@ the generator will render its `attributes`.
 
 #### Defined in
 
-[utils/static.ts:119](https://github.com/globus/static-data-portal/blob/1b3fe99b60b8d3ee1c63518384fabe5e257a214e/utils/static.ts#L119)
+[utils/static.ts:115](https://github.com/globus/static-data-portal/blob/7049be242b3135e7c2d5b874f564022879c85966/utils/static.ts#L115)
 
 ## Modules
 

--- a/docs/globals.md
+++ b/docs/globals.md
@@ -75,7 +75,7 @@ https://github.com/from-static/actions
 
 #### Defined in
 
-[utils/static.ts:8](https://github.com/globus/static-data-portal/blob/1b3fe99b60b8d3ee1c63518384fabe5e257a214e/utils/static.ts#L8)
+[utils/static.ts:9](https://github.com/globus/static-data-portal/blob/7049be242b3135e7c2d5b874f564022879c85966/utils/static.ts#L9)
 
 ***
 
@@ -177,21 +177,9 @@ To use the portal's built-in authorization handling, redirects should be sent to
 
 ##### attributes.globus.transfer
 
-> **transfer**: `object`
+> **transfer**: [`TransferCollectionConfiguration`](-internal-.md#transfercollectionconfiguration) \| `object`
 
 Configuration for Transfer-related functionality in the portal.
-
-##### attributes.globus.transfer.collection\_id
-
-> **collection\_id**: `string`
-
-The UUID of the Globus collection to list and transfer files from.
-
-##### attributes.globus.transfer.path?
-
-> `optional` **path**: `string`
-
-The path on the collection to list and transfer files from.
 
 ##### attributes.theme?
 
@@ -212,7 +200,7 @@ the generator will render its `attributes`.
 
 #### Defined in
 
-[utils/static.ts:38](https://github.com/globus/static-data-portal/blob/1b3fe99b60b8d3ee1c63518384fabe5e257a214e/utils/static.ts#L38)
+[utils/static.ts:39](https://github.com/globus/static-data-portal/blob/7049be242b3135e7c2d5b874f564022879c85966/utils/static.ts#L39)
 
 ***
 
@@ -228,7 +216,7 @@ the generator will render its `attributes`.
 
 #### Defined in
 
-[utils/static.ts:119](https://github.com/globus/static-data-portal/blob/1b3fe99b60b8d3ee1c63518384fabe5e257a214e/utils/static.ts#L119)
+[utils/static.ts:115](https://github.com/globus/static-data-portal/blob/7049be242b3135e7c2d5b874f564022879c85966/utils/static.ts#L115)
 
 ## Modules
 

--- a/static.json
+++ b/static.json
@@ -7,9 +7,6 @@
   "data": {
     "version": "1.0.0",
     "attributes": {
-      "theme": {
-        "colorScheme": "brand"
-      },
       "content": {
         "title": "Globus : Data Distribution Portal",
         "subtitle": "An example of a data distribution portal built with Globus.",

--- a/theme.ts
+++ b/theme.ts
@@ -1,6 +1,10 @@
 import { STATIC } from "./utils/static";
 
-import { extendTheme, withDefaultColorScheme } from "@chakra-ui/react";
+import {
+  theme as baseTheme,
+  extendTheme,
+  withDefaultColorScheme,
+} from "@chakra-ui/react";
 
 export type ColorDefinition =
   | {
@@ -26,12 +30,12 @@ export type ThemeSettings = {
   colorScheme?: string;
   /**
    * Specific color definitions to use in the theme.
-   * The most common use case is to define a `brand` color.
+   * The most common use case is to define a `primary` color.
    * @example
    * ```json
    * {
    *   "colors": {
-   *     "brand": {
+   *     "primary": {
    *      "50": "#E5F2FF",
    *      "100": "#B8DBFF",
    *      "200": "#8AC4FF",
@@ -56,7 +60,7 @@ export type ThemeSettings = {
   extendTheme?: Parameters<typeof extendTheme>[0];
 };
 
-const brand: ColorDefinition = {
+const primary: ColorDefinition = {
   "50": "#E5F2FF",
   "100": "#B8DBFF",
   "200": "#8AC4FF",
@@ -69,12 +73,20 @@ const brand: ColorDefinition = {
   "900": "#001933",
 };
 
-let colorScheme = {};
-if (STATIC.data.attributes.theme?.colorScheme) {
-  colorScheme = withDefaultColorScheme({
-    colorScheme: STATIC.data.attributes.theme?.colorScheme,
-  });
-}
+const secondary = baseTheme.colors.gray;
+
+const colorScheme = withDefaultColorScheme({
+  colorScheme:
+    /**
+     * Ensure legacy "brand" color scheme uses the new "primary" color scheme.
+     */
+    STATIC.data.attributes.theme?.colorScheme === "brand"
+      ? "primary"
+      : /**
+         * If no color scheme is provided, use the "primary" color scheme.
+         */
+        STATIC.data.attributes.theme?.colorScheme || "primary",
+});
 
 const activeLabelStyles = {
   transform: "scale(0.85) translateY(-24px)",
@@ -116,7 +128,11 @@ const theme = extendTheme(
   },
   {
     colors: {
-      brand,
+      /**
+       * Allow the legacy "brand" to be used as the primary color.
+       */
+      primary: STATIC.data.attributes.theme?.colors?.brand || primary,
+      secondary,
       ...(STATIC.data.attributes.theme?.colors || {}),
     },
   },


### PR DESCRIPTION
- Set "primary" as the default colorScheme
- Regenerate docs